### PR TITLE
Add IP address lookup page with geolocation

### DIFF
--- a/apps/web/app/ip/page.tsx
+++ b/apps/web/app/ip/page.tsx
@@ -1,0 +1,146 @@
+import { headers } from "next/headers";
+import Link from "next/link";
+import Script from "next/script";
+import geoip from "geoip-lite";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Your IP Address",
+  description:
+    "See your IP address and approximate location. All lookups are local — no data leaves the server.",
+  alternates: {
+    canonical: "https://solun.pm/ip",
+  },
+  openGraph: {
+    title: "Your IP Address · Solun",
+    description:
+      "See your IP address and approximate location, looked up entirely server-side.",
+    url: "https://solun.pm/ip",
+    type: "website" as const,
+  },
+};
+
+function getIpFromHeaders(headersList: Headers): string {
+  const forwarded = headersList.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0]!.trim();
+  }
+  return headersList.get("x-real-ip") ?? "unknown";
+}
+
+export default async function IpPage() {
+  const headersList = await headers();
+  const ip = getIpFromHeaders(headersList);
+  const version = ip.includes(":") ? 6 : 4;
+  const geo = geoip.lookup(ip);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: "Your IP Address",
+    description:
+      "View your IP address and approximate location with a privacy-first lookup.",
+    url: "https://solun.pm/ip",
+    publisher: { "@type": "Organization", name: "Solun" },
+  };
+
+  const locationRows = geo
+    ? [
+        { label: "City", value: geo.city || "—" },
+        { label: "Region", value: geo.region || "—" },
+        { label: "Country", value: geo.country || "—" },
+        { label: "Timezone", value: geo.timezone || "—" },
+        {
+          label: "Coordinates",
+          value: geo.ll ? `${geo.ll[0]}, ${geo.ll[1]}` : "—",
+        },
+      ]
+    : null;
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-4 py-10">
+      <div className="w-full max-w-2xl space-y-8 rounded-3xl border border-ink-700 bg-ink-800/70 p-8 shadow-glow backdrop-blur">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.4em] text-tide-300/70">
+            Solun · IP Lookup
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight text-ink-100">
+            Your IP Address
+          </h1>
+          <p className="text-sm text-ink-200">
+            This is the address your device used to connect. The location is
+            looked up from a local database — nothing leaves the server.
+          </p>
+        </header>
+
+        <section className="space-y-4 rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
+          <div className="flex items-center gap-3">
+            <span className="font-mono text-2xl font-semibold text-ink-100 break-all">
+              {ip}
+            </span>
+            <span className="rounded-full bg-tide-300/15 px-2.5 py-0.5 text-xs font-medium text-tide-300">
+              IPv{version}
+            </span>
+          </div>
+        </section>
+
+        {locationRows ? (
+          <section className="space-y-3 rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
+            <h2 className="text-sm uppercase tracking-[0.3em] text-tide-300/80">
+              Location
+            </h2>
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+              {locationRows.map((row) => (
+                <div key={row.label}>
+                  <dt className="text-ink-400">{row.label}</dt>
+                  <dd className="font-medium text-ink-100">{row.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ) : (
+          <section className="rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
+            <p className="text-sm text-ink-400">
+              Location data is not available for this IP address.
+            </p>
+          </section>
+        )}
+
+        <section className="space-y-3 border-t border-ink-700 pt-6 text-sm text-ink-200">
+          <Link
+            href="/"
+            className="text-tide-300 transition hover:text-tide-200"
+          >
+            Back to Solun
+          </Link>
+          <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.3em]">
+            <Link
+              href="/learn"
+              className="text-tide-300 transition hover:text-tide-200"
+            >
+              Learn
+            </Link>
+            <Link
+              href="/roadmap"
+              className="text-tide-300 transition hover:text-tide-200"
+            >
+              Roadmap
+            </Link>
+            <a
+              href="https://github.com/solun-pm/solun"
+              className="text-tide-300 transition hover:text-tide-200"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub
+            </a>
+          </div>
+        </section>
+      </div>
+      <Script id="ip-jsonld" type="application/ld+json">
+        {JSON.stringify(jsonLd)}
+      </Script>
+    </main>
+  );
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -26,6 +26,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${siteUrl}/roadmap`,
       lastModified: new Date()
     },
+    {
+      url: `${siteUrl}/ip`,
+      lastModified: new Date()
+    },
     ...learnEntries
   ];
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@solun/shared": "workspace:*",
     "clsx": "^2.1.1",
+    "geoip-lite": "^2.0.1",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
+    "@types/geoip-lite": "^1.4.4",
     "@types/node": "^25.5.0",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      geoip-lite:
+        specifier: ^2.0.1
+        version: 2.0.1
       next:
         specifier: 16.2.1
         version: 16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -112,6 +115,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
+      '@types/geoip-lite':
+        specifier: ^1.4.4
+        version: 1.4.4
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -1565,6 +1571,9 @@ packages:
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
 
+  '@types/geoip-lite@1.4.4':
+    resolution: {integrity: sha512-2uVfn+C6bX/H356H6mjxsWUA5u8LO8dJgSBIRO/NFlpMe4DESzacutD/rKYrTDKm1Ugv78b4Wz1KvpHrlv3jSw==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
@@ -1669,6 +1678,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -2048,6 +2060,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  geoip-lite@2.0.1:
+    resolution: {integrity: sha512-cR9E28nu1a6dsvzB1tANhdmCyXWV1L4AiSCT9alHLIUl06599EGu33mqY99ieU0twQob0kfcDQ/sAUBvHb7swA==}
+    engines: {node: '>=24.0.0'}
+
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
@@ -2128,6 +2144,10 @@ packages:
   http-status-codes@2.3.0:
     resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -2150,6 +2170,10 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  ip-address@5.9.4:
+    resolution: {integrity: sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==}
+    engines: {node: '>= 0.10'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2195,6 +2219,9 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsbn@1.1.0:
+    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -2231,6 +2258,10 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
       typescript: '>=5.0.4 <7'
+
+  lazy@1.0.11:
+    resolution: {integrity: sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==}
+    engines: {node: '>=0.2.0'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2312,6 +2343,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
@@ -2508,6 +2542,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -2777,6 +2814,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.1.2:
+    resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
+
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
@@ -2945,6 +2985,10 @@ packages:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yauzl@3.2.1:
+    resolution: {integrity: sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4617,6 +4661,8 @@ snapshots:
       '@types/express-serve-static-core': 5.1.1
       '@types/serve-static': 2.2.0
 
+  '@types/geoip-lite@1.4.4': {}
+
   '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
@@ -4736,6 +4782,8 @@ snapshots:
       electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-crc32@0.2.13: {}
 
   busboy@1.6.0:
     dependencies:
@@ -5149,6 +5197,14 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  geoip-lite@2.0.1:
+    dependencies:
+      chalk: 4.1.2
+      iconv-lite: 0.6.3
+      ip-address: 5.9.4
+      lazy: 1.0.11
+      yauzl: 3.2.1
+
   get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
@@ -5230,6 +5286,10 @@ snapshots:
 
   http-status-codes@2.3.0: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -5246,6 +5306,12 @@ snapshots:
   inherits@2.0.4: {}
 
   ip-address@10.1.0: {}
+
+  ip-address@5.9.4:
+    dependencies:
+      jsbn: 1.1.0
+      lodash: 4.17.23
+      sprintf-js: 1.1.2
 
   ipaddr.js@1.9.1: {}
 
@@ -5274,6 +5340,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsbn@1.1.0: {}
 
   jsesc@3.1.0: {}
 
@@ -5313,6 +5381,8 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  lazy@1.0.11: {}
 
   levn@0.4.1:
     dependencies:
@@ -5373,6 +5443,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.23: {}
 
   log-symbols@7.0.1:
     dependencies:
@@ -5589,6 +5661,8 @@ snapshots:
   path-to-regexp@8.4.0: {}
 
   pathe@2.0.3: {}
+
+  pend@1.2.0: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -5900,6 +5974,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.1.2: {}
+
   sqlstring@2.3.3: {}
 
   statuses@2.0.2: {}
@@ -6025,6 +6101,11 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
+
+  yauzl@3.2.1:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
This PR adds a new IP address lookup page that displays the user's IP address and approximate geolocation information. The lookup is performed entirely server-side using a local geoip database, ensuring no data leaves the server.

## Key Changes
- **New IP lookup page** (`apps/web/app/ip/page.tsx`): 
  - Displays the user's IP address with IPv4/IPv6 version indicator
  - Shows geolocation data (city, region, country, timezone, coordinates) from a local geoip database
  - Includes proper metadata and SEO tags with Open Graph support
  - Implements JSON-LD structured data for better search engine indexing
  - Features privacy-first messaging emphasizing server-side processing
  - Styled with the existing design system (ink/tide color palette)

- **Updated sitemap** (`apps/web/app/sitemap.ts`): Added `/ip` route to the sitemap for SEO discoverability

- **Dependencies**: Added `geoip-lite` package for local IP geolocation lookups and its TypeScript types

## Implementation Details
- Uses Next.js `headers()` API to extract the client IP from `x-forwarded-for` or `x-real-ip` headers
- Automatically detects IPv4 vs IPv6 based on colon presence in the address
- Gracefully handles cases where geolocation data is unavailable
- Page is marked as `force-dynamic` to ensure fresh IP detection on each request
- Includes navigation links to other Solun pages and external resources (GitHub)

https://claude.ai/code/session_01CHgeu6QibcSebavzwefF7V