### PR TITLE
Fix geoip-lite build error by marking it as server external package

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,6 @@
 const nextConfig = {
-  transpilePackages: ["@solun/shared"]
+  transpilePackages: ["@solun/shared"],
+  serverExternalPackages: ["geoip-lite"]
 };
 
 export default nextConfig;


### PR DESCRIPTION
Turbopack was trying to bundle geoip-lite's binary .dat data files, causing ENOENT errors. Adding it to serverExternalPackages keeps the package as a native require at runtime.

https://claude.ai/code/session_01CHgeu6QibcSebavzwefF7V