### PR TITLE
Add dual-stack IPv4/IPv6 detection with CLI support

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solun/api",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/app/api/ip/route.ts
+++ b/apps/web/app/api/ip/route.ts
@@ -1,0 +1,58 @@
+import { headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import geoip from "geoip-lite";
+import {
+  getIpFromHeaders,
+  getIpVersion,
+  extractGeo,
+  formatPlainText,
+} from "../../../lib/ip";
+
+export const dynamic = "force-dynamic";
+
+const CLI_PATTERN =
+  /^(curl|Wget|HTTPie|httpie|fetch|libcurl|python-requests|Go-http-client|PowerShell|aria2)/i;
+
+function corsHeaders(request: NextRequest): Record<string, string> {
+  const origin = request.headers.get("origin") ?? "";
+  if (/^https?:\/\/([a-z0-9-]+\.)*solun\.pm(:\d+)?$/.test(origin)) {
+    return {
+      "Access-Control-Allow-Origin": origin,
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    };
+  }
+  return {};
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: corsHeaders(request),
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const headersList = await headers();
+  const ip = getIpFromHeaders(headersList);
+  const version = getIpVersion(ip);
+  const geo = extractGeo(geoip.lookup(ip));
+
+  const ua = headersList.get("user-agent") ?? "";
+  const wantsText =
+    CLI_PATTERN.test(ua) ||
+    request.nextUrl.searchParams.get("format") === "text";
+
+  const cors = corsHeaders(request);
+
+  if (wantsText) {
+    return new NextResponse(formatPlainText(ip, version, geo), {
+      headers: { "Content-Type": "text/plain; charset=utf-8", ...cors },
+    });
+  }
+
+  return NextResponse.json(
+    { ip, version, ...(geo ?? {}) },
+    { headers: cors },
+  );
+}

--- a/apps/web/app/ip/dual-stack.tsx
+++ b/apps/web/app/ip/dual-stack.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { IpInfo, GeoResult } from "../../lib/ip";
+
+interface StackEntry {
+  ip: string;
+  version: 4 | 6;
+  geo: GeoResult | null;
+}
+
+interface DualStackState {
+  v4: StackEntry | null;
+  v6: StackEntry | null;
+  v4Loading: boolean;
+  v6Loading: boolean;
+}
+
+async function fetchStack(url: string): Promise<StackEntry | null> {
+  try {
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      ip: data.ip,
+      version: data.version,
+      geo: data.city
+        ? {
+            city: data.city,
+            region: data.region,
+            country: data.country,
+            timezone: data.timezone,
+            coordinates: data.coordinates,
+          }
+        : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function IpCard({
+  label,
+  entry,
+  loading,
+}: {
+  label: string;
+  entry: StackEntry | null;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <section className="space-y-4 rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
+        <h2 className="text-sm uppercase tracking-[0.3em] text-tide-300/80">
+          {label}
+        </h2>
+        <div className="flex items-center gap-3">
+          <div className="h-7 w-48 animate-pulse rounded-lg bg-ink-700" />
+        </div>
+      </section>
+    );
+  }
+
+  if (!entry) {
+    return (
+      <section className="space-y-4 rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
+        <h2 className="text-sm uppercase tracking-[0.3em] text-tide-300/80">
+          {label}
+        </h2>
+        <p className="text-sm text-ink-400">Nicht verfügbar</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4 rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
+      <h2 className="text-sm uppercase tracking-[0.3em] text-tide-300/80">
+        {label}
+      </h2>
+      <div className="flex items-center gap-3">
+        <span className="break-all font-mono text-2xl font-semibold text-ink-100">
+          {entry.ip}
+        </span>
+        <span className="rounded-full bg-tide-300/15 px-2.5 py-0.5 text-xs font-medium text-tide-300">
+          IPv{entry.version}
+        </span>
+      </div>
+      {entry.geo && (
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+          {[
+            { label: "City", value: entry.geo.city },
+            { label: "Region", value: entry.geo.region },
+            { label: "Country", value: entry.geo.country },
+            { label: "Timezone", value: entry.geo.timezone },
+            { label: "Coordinates", value: entry.geo.coordinates },
+          ].map((row) => (
+            <div key={row.label}>
+              <dt className="text-ink-400">{row.label}</dt>
+              <dd className="font-medium text-ink-100">{row.value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </section>
+  );
+}
+
+export default function DualStack({
+  serverIp,
+}: {
+  serverIp: IpInfo;
+}) {
+  const [state, setState] = useState<DualStackState>(() => {
+    // Pre-fill the version we already know from the server render
+    const initial: DualStackState = {
+      v4: null,
+      v6: null,
+      v4Loading: true,
+      v6Loading: true,
+    };
+    if (serverIp.version === 4) {
+      initial.v4 = { ip: serverIp.ip, version: 4, geo: serverIp.geo };
+      initial.v4Loading = false;
+    } else {
+      initial.v6 = { ip: serverIp.ip, version: 6, geo: serverIp.geo };
+      initial.v6Loading = false;
+    }
+    return initial;
+  });
+
+  useEffect(() => {
+    // Fetch the missing stack from the dedicated subdomain
+    if (serverIp.version === 4) {
+      // We already have v4, fetch v6
+      fetchStack("https://v6.solun.pm/api/ip").then((entry) =>
+        setState((s) => ({ ...s, v6: entry, v6Loading: false })),
+      );
+    } else {
+      // We already have v6, fetch v4
+      fetchStack("https://v4.solun.pm/api/ip").then((entry) =>
+        setState((s) => ({ ...s, v4: entry, v4Loading: false })),
+      );
+    }
+  }, [serverIp.version]);
+
+  return (
+    <div className="space-y-4">
+      <IpCard label="IPv4" entry={state.v4} loading={state.v4Loading} />
+      <IpCard label="IPv6" entry={state.v6} loading={state.v6Loading} />
+    </div>
+  );
+}

--- a/apps/web/app/ip/page.tsx
+++ b/apps/web/app/ip/page.tsx
@@ -2,61 +2,42 @@ import { headers } from "next/headers";
 import Link from "next/link";
 import Script from "next/script";
 import geoip from "geoip-lite";
+import { getIpFromHeaders, getIpVersion, extractGeo } from "../../lib/ip";
+import DualStack from "./dual-stack";
 
 export const dynamic = "force-dynamic";
 
 export const metadata = {
   title: "Your IP Address",
   description:
-    "See your IP address and approximate location. All lookups are local — no data leaves the server.",
+    "See your IPv4 and IPv6 addresses and approximate location. All lookups are local — no data leaves the server.",
   alternates: {
     canonical: "https://solun.pm/ip",
   },
   openGraph: {
     title: "Your IP Address · Solun",
     description:
-      "See your IP address and approximate location, looked up entirely server-side.",
+      "See your IPv4 and IPv6 addresses, looked up entirely server-side.",
     url: "https://solun.pm/ip",
     type: "website" as const,
   },
 };
 
-function getIpFromHeaders(headersList: Headers): string {
-  const forwarded = headersList.get("x-forwarded-for");
-  if (forwarded) {
-    return forwarded.split(",")[0]!.trim();
-  }
-  return headersList.get("x-real-ip") ?? "unknown";
-}
-
 export default async function IpPage() {
   const headersList = await headers();
   const ip = getIpFromHeaders(headersList);
-  const version = ip.includes(":") ? 6 : 4;
-  const geo = geoip.lookup(ip);
+  const version = getIpVersion(ip);
+  const geo = extractGeo(geoip.lookup(ip));
 
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "WebPage",
     name: "Your IP Address",
     description:
-      "View your IP address and approximate location with a privacy-first lookup.",
+      "View your IPv4 and IPv6 addresses with a privacy-first lookup.",
     url: "https://solun.pm/ip",
     publisher: { "@type": "Organization", name: "Solun" },
   };
-
-  const locationRows = geo
-    ? [
-        { label: "City", value: geo.city || "—" },
-        { label: "Region", value: geo.region || "—" },
-        { label: "Country", value: geo.country || "—" },
-        { label: "Timezone", value: geo.timezone || "—" },
-        {
-          label: "Coordinates",
-          value: geo.ll ? `${geo.ll[0]}, ${geo.ll[1]}` : "—",
-        },
-      ]
-    : null;
 
   return (
     <main className="flex min-h-screen items-center justify-center px-4 py-10">
@@ -69,43 +50,24 @@ export default async function IpPage() {
             Your IP Address
           </h1>
           <p className="text-sm text-ink-200">
-            This is the address your device used to connect. The location is
-            looked up from a local database — nothing leaves the server.
+            These are the addresses your device used to connect. All lookups
+            are local — nothing leaves the server.
           </p>
         </header>
 
-        <section className="space-y-4 rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
-          <div className="flex items-center gap-3">
-            <span className="font-mono text-2xl font-semibold text-ink-100 break-all">
-              {ip}
-            </span>
-            <span className="rounded-full bg-tide-300/15 px-2.5 py-0.5 text-xs font-medium text-tide-300">
-              IPv{version}
-            </span>
-          </div>
-        </section>
+        <DualStack serverIp={{ ip, version, geo }} />
 
-        {locationRows ? (
-          <section className="space-y-3 rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
-            <h2 className="text-sm uppercase tracking-[0.3em] text-tide-300/80">
-              Location
-            </h2>
-            <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
-              {locationRows.map((row) => (
-                <div key={row.label}>
-                  <dt className="text-ink-400">{row.label}</dt>
-                  <dd className="font-medium text-ink-100">{row.value}</dd>
-                </div>
-              ))}
-            </dl>
-          </section>
-        ) : (
-          <section className="rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
-            <p className="text-sm text-ink-400">
-              Location data is not available for this IP address.
-            </p>
-          </section>
-        )}
+        <section className="space-y-4 rounded-2xl border border-ink-700 bg-ink-900/60 p-6">
+          <h2 className="text-sm uppercase tracking-[0.3em] text-tide-300/80">
+            Terminal
+          </h2>
+          <p className="text-sm text-ink-200">
+            You can also check your IP from the command line:
+          </p>
+          <pre className="rounded-xl bg-ink-950 px-4 py-3 font-mono text-sm text-tide-300 select-all">
+            curl solun.pm/ip
+          </pre>
+        </section>
 
         <section className="space-y-3 border-t border-ink-700 pt-6 text-sm text-ink-200">
           <Link

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1091,6 +1091,9 @@ function HomeLayout({
             <Link href="/roadmap" className="text-tide-300 hover:text-tide-200 transition">
               Roadmap
             </Link>
+            <Link href="/ip" className="text-tide-300 hover:text-tide-200 transition">
+              IP
+            </Link>
             <a
               href="https://github.com/solun-pm/solun"
               className="inline-flex items-center gap-2 text-tide-300 hover:text-tide-200 transition"

--- a/apps/web/lib/ip.ts
+++ b/apps/web/lib/ip.ts
@@ -1,0 +1,59 @@
+import type { Lookup } from "geoip-lite";
+
+export function getIpFromHeaders(headersList: Headers): string {
+  const forwarded = headersList.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0]!.trim();
+  }
+  return headersList.get("x-real-ip") ?? "unknown";
+}
+
+export function getIpVersion(ip: string): 4 | 6 {
+  return ip.includes(":") ? 6 : 4;
+}
+
+export interface GeoResult {
+  city: string;
+  region: string;
+  country: string;
+  timezone: string;
+  coordinates: string;
+}
+
+export function extractGeo(geo: Lookup | null): GeoResult | null {
+  if (!geo) return null;
+  return {
+    city: geo.city || "—",
+    region: geo.region || "—",
+    country: geo.country || "—",
+    timezone: geo.timezone || "—",
+    coordinates: geo.ll ? `${geo.ll[0]}, ${geo.ll[1]}` : "—",
+  };
+}
+
+export function formatPlainText(
+  ip: string,
+  version: 4 | 6,
+  geo: GeoResult | null,
+): string {
+  const lines = [
+    `IP:          ${ip}`,
+    `Version:     IPv${version}`,
+  ];
+  if (geo) {
+    lines.push(
+      `City:        ${geo.city}`,
+      `Region:      ${geo.region}`,
+      `Country:     ${geo.country}`,
+      `Timezone:    ${geo.timezone}`,
+      `Coordinates: ${geo.coordinates}`,
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+export interface IpInfo {
+  ip: string;
+  version: 4 | 6;
+  geo: GeoResult | null;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,49 +1,30 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-/**
- * Security headers middleware for Solun
- * Implements critical security headers for a privacy-focused application
- */
-export function proxy(request: NextRequest) {
-  const response = NextResponse.next();
+const CLI_PATTERN =
+  /^(curl|Wget|HTTPie|httpie|fetch|libcurl|python-requests|Go-http-client|PowerShell|aria2)/i;
 
-  // Strict-Transport-Security (HSTS)
-  // Forces HTTPS for 1 year, includes all subdomains, eligible for browser preload list
+function applySecurityHeaders(response: NextResponse): void {
   response.headers.set(
     "Strict-Transport-Security",
-    "max-age=31536000; includeSubDomains; preload"
+    "max-age=31536000; includeSubDomains; preload",
   );
-
-  // X-Frame-Options
-  // Prevents clickjacking by disabling iframe embedding entirely
   response.headers.set("X-Frame-Options", "DENY");
-
-  // X-Content-Type-Options
-  // Prevents MIME type sniffing attacks
   response.headers.set("X-Content-Type-Options", "nosniff");
-
-  // Referrer-Policy
-  // Controls referrer information sent to other sites
   response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-
-  // Permissions-Policy
-  // Disables unnecessary browser features
   response.headers.set(
     "Permissions-Policy",
-    "geolocation=(), microphone=(), camera=()"
+    "geolocation=(), microphone=(), camera=()",
   );
 
-  // Content-Security-Policy
-  // Note: Next.js requires 'unsafe-inline' and 'unsafe-eval' for development
-  // Consider tightening this in production with nonces
   const connectSources = new Set<string>(["'self'"]);
+
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
   if (apiUrl) {
     try {
       connectSources.add(new URL(apiUrl).origin);
     } catch {
-      // Ignore invalid API URL to avoid breaking CSP generation
+      // ignore
     }
   } else if (process.env.NODE_ENV !== "production") {
     connectSources.add("http://localhost:3001");
@@ -53,17 +34,17 @@ export function proxy(request: NextRequest) {
   if (extraConnect) {
     extraConnect
       .split(",")
-      .map((value) => value.trim())
+      .map((v) => v.trim())
       .filter(Boolean)
-      .forEach((value) => {
-        if (value.includes("*")) {
-          connectSources.add(value);
+      .forEach((v) => {
+        if (v.includes("*")) {
+          connectSources.add(v);
           return;
         }
         try {
-          connectSources.add(new URL(value).origin);
+          connectSources.add(new URL(v).origin);
         } catch {
-          connectSources.add(value);
+          connectSources.add(v);
         }
       });
   }
@@ -73,11 +54,13 @@ export function proxy(request: NextRequest) {
     try {
       connectSources.add(new URL(r2Endpoint).origin);
     } catch {
-      // ignore malformed value
+      // ignore
     }
   }
 
-  const r2Public = process.env.NEXT_PUBLIC_R2_PUBLIC_URL ?? process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN;
+  const r2Public =
+    process.env.NEXT_PUBLIC_R2_PUBLIC_URL ??
+    process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN;
   if (r2Public) {
     try {
       connectSources.add(new URL(r2Public).origin);
@@ -86,9 +69,12 @@ export function proxy(request: NextRequest) {
     }
   }
 
-  // Allow Cloudflare R2 endpoints for metadata/file fetches.
   connectSources.add("https://*.r2.cloudflarestorage.com");
   connectSources.add("https://*.eu.r2.cloudflarestorage.com");
+
+  // Allow fetches to v4/v6 subdomains for dual-stack IP detection
+  connectSources.add("https://v4.solun.pm");
+  connectSources.add("https://v6.solun.pm");
 
   const csp = [
     "default-src 'self'",
@@ -97,23 +83,31 @@ export function proxy(request: NextRequest) {
     "img-src 'self' data: https:",
     "font-src 'self' data:",
     `connect-src ${Array.from(connectSources).join(" ")}`,
-    "frame-ancestors 'none'"
+    "frame-ancestors 'none'",
   ].join("; ");
 
   response.headers.set("Content-Security-Policy", csp);
+}
 
+export function middleware(request: NextRequest) {
+  // Rewrite CLI requests to /ip → /api/ip with plain-text format
+  if (request.nextUrl.pathname === "/ip") {
+    const ua = request.headers.get("user-agent") ?? "";
+    if (CLI_PATTERN.test(ua)) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/api/ip";
+      url.searchParams.set("format", "text");
+      const response = NextResponse.rewrite(url);
+      applySecurityHeaders(response);
+      return response;
+    }
+  }
+
+  const response = NextResponse.next();
+  applySecurityHeaders(response);
   return response;
 }
 
-// Apply middleware to all routes
 export const config = {
-  matcher: [
-    /*
-     * Match all request paths except:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     */
-    "/((?!_next/static|_next/image|favicon.ico).*)"
-  ]
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solun/web",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solun/shared",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "private": true,
   "type": "module",
   "main": "./dist/types.js",


### PR DESCRIPTION
## Summary
This PR adds comprehensive IPv4 and IPv6 detection capabilities to the IP address lookup feature, including a new API endpoint and CLI-friendly plain-text output format.

## Key Changes

- **New API endpoint** (`/api/ip`): Provides IP information in both JSON and plain-text formats
  - Detects CLI user agents (curl, wget, etc.) and returns plain-text by default
  - Supports `?format=text` query parameter for explicit format selection
  - Implements CORS for solun.pm subdomains to enable cross-subdomain requests

- **Dual-stack IP detection**: New `DualStack` component that displays both IPv4 and IPv6 addresses
  - Server-renders the detected IP version
  - Client-side fetches the opposite stack from dedicated subdomains (v4.solun.pm, v6.solun.pm)
  - Shows loading states and graceful fallbacks for unavailable stacks

- **Shared IP utilities** (`lib/ip.ts`): Extracted common IP detection logic
  - `getIpFromHeaders()`: Extracts IP from X-Forwarded-For or X-Real-IP headers
  - `getIpVersion()`: Determines IPv4 vs IPv6
  - `extractGeo()`: Normalizes geoip-lite lookup results
  - `formatPlainText()`: Formats IP data for CLI output

- **Middleware updates**: Enhanced request routing
  - Rewrites `/ip` requests from CLI tools to `/api/ip?format=text`
  - Refactored security header application into reusable function
  - Added CSP allowlist entries for v4/v6 subdomains

- **UI improvements**: Updated IP page layout
  - Replaced single IP display with dual-stack component
  - Added terminal section showing `curl solun.pm/ip` command
  - Updated metadata descriptions to reflect dual-stack capability

## Implementation Details

- The dual-stack component uses a hybrid approach: server-side rendering provides the initial IP, while client-side fetches retrieve the opposite stack asynchronously
- CORS is restricted to solun.pm subdomains via origin pattern matching
- Plain-text output format is auto-detected based on User-Agent but can be explicitly requested
- All geolocation lookups remain local (geoip-lite) with no external data transmission

https://claude.ai/code/session_01MAcEBa271Fsw8RsubzhFtt