### PR TITLE
Fix curl returning nothing and footer links not clickable

### DIFF
--- a/apps/web/app/ip/page.tsx
+++ b/apps/web/app/ip/page.tsx
@@ -65,7 +65,7 @@ export default async function IpPage() {
             You can also check your IP from the command line:
           </p>
           <pre className="rounded-xl bg-ink-950 px-4 py-3 font-mono text-sm text-tide-300 select-all">
-            curl solun.pm/ip
+curl https://solun.pm/ip
           </pre>
         </section>
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1082,7 +1082,7 @@ function HomeLayout({
           </section>
         </div>
 
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-ink-700 pt-6 text-xs text-ink-200/70">
+        <div className="relative z-10 flex flex-wrap items-center justify-between gap-3 border-t border-ink-700 pt-6 text-xs text-ink-200/70">
           <span>Made with love by the Solun team</span>
           <div className="flex items-center gap-4">
             <Link href="/learn" className="text-tide-300 hover:text-tide-200 transition">

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -89,17 +89,28 @@ function applySecurityHeaders(response: NextResponse): void {
   response.headers.set("Content-Security-Policy", csp);
 }
 
+function getIpFromRequest(request: NextRequest): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0]!.trim();
+  }
+  return request.headers.get("x-real-ip") ?? "unknown";
+}
+
 export function middleware(request: NextRequest) {
-  // Rewrite CLI requests to /ip → /api/ip with plain-text format
+  // Return plain-text IP directly for CLI clients hitting /ip
   if (request.nextUrl.pathname === "/ip") {
     const ua = request.headers.get("user-agent") ?? "";
     if (CLI_PATTERN.test(ua)) {
-      const url = request.nextUrl.clone();
-      url.pathname = "/api/ip";
-      url.searchParams.set("format", "text");
-      const response = NextResponse.rewrite(url);
-      applySecurityHeaders(response);
-      return response;
+      const ip = getIpFromRequest(request);
+      const version = ip.includes(":") ? 6 : 4;
+      const body = `${ip}\n`;
+      return new NextResponse(body, {
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+          "X-IP-Version": `IPv${version}`,
+        },
+      });
     }
   }
 


### PR DESCRIPTION
- Curl: return plain-text IP directly from middleware instead of rewrite to /api/ip (avoids potential Edge/Node runtime issues behind Traefik)
- Footer: add relative z-10 so absolute panels don't overlay footer links
- Curl hint: use explicit https:// in the example command

https://claude.ai/code/session_01MAcEBa271Fsw8RsubzhFtt